### PR TITLE
rename jobs

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -2,7 +2,7 @@ name: Code Quality
 on: [pull_request]
 
 jobs:
-  build:
+  linting:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
       - "*"
 
 jobs:
-  build:
+  testing:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:


### PR DESCRIPTION
to make it easier and clearer for the branch protection rules.