### PR TITLE
Fix overflow when encoding non-python data types

### DIFF
--- a/phe/encoding.py
+++ b/phe/encoding.py
@@ -188,8 +188,8 @@ class EncodedNumber(object):
             exponent = min(max_exponent, prec_exponent)
 
         # Use rationals instead of floats to avoid overflow.
-        int_rep = round(fractions.Fraction(scalar)
-                        * fractions.Fraction(cls.BASE) ** -exponent)
+        int_rep = int(round(fractions.Fraction(scalar)
+                        * fractions.Fraction(cls.BASE) ** -exponent))
 
         if abs(int_rep) > public_key.max_int:
             raise ValueError('Integer needs to be within +/- %d but got %d'

--- a/phe/tests/paillier_test.py
+++ b/phe/tests/paillier_test.py
@@ -25,6 +25,7 @@ import logging
 import unittest
 import sys
 import math
+import numpy
 
 from phe import paillier
 
@@ -1094,6 +1095,10 @@ class TestIssue62(unittest.TestCase):
         # This will raise OverflowError without bugfix #73.
         priv.decrypt(a + b)
 
+class TestNumpyOverflow(unittest.TestCase):
+    def testNumpyOverflow(self):
+        public_key, private_key = paillier.generate_paillier_keypair()
+        private_key.decrypt(public_key.encrypt(numpy.int64(0),precision=2**-12))
 
 def main():
     unittest.main()


### PR DESCRIPTION
See [Issue#116](https://github.com/data61/python-paillier/issues/116) for an example of the issue.

Added a UnitTest that fails without the fix. UnitTest requires Numpy to work, as Numpy has data types such as int64 that cause overflow because the int_rep conversion doesn't properly convert into a python int, which is needed to prevent overflow in the modulus operation.

One Working fix is to just convert the int_rep into a python int manually by wrapping it in the int() function.